### PR TITLE
Use restmapper from controller-runtime rather than operator-sdk.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -79,15 +79,16 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:982367f8aabab5e69c08416597055d15614c3a8c037098c94cc1a3c863b26eab"
+  digest = "1:06a0d9b156b459a988b70c9f5d7ce3dc0a0231fe5329eb56dd1cfd7704c6fa19"
   name = "github.com/manifestival/manifestival"
   packages = [
     ".",
+    "overlay",
     "patch",
     "sources",
   ]
   pruneopts = "UT"
-  revision = "996a3dc7d51032bcb1880bae8b211c8ce219320e"
+  revision = "15996b119a3d7b7ea059528df3dbbbf4f5b93017"
 
 [[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
@@ -104,14 +105,6 @@
   pruneopts = "UT"
   revision = "94122c33edd36123c84d5368cfb2b69df93a0ec8"
   version = "v1.0.1"
-
-[[projects]]
-  digest = "1:a9c110560d6c7ae97fe37ca11a1eb711c41cd154121b36bee7284289d8d21739"
-  name = "github.com/operator-framework/operator-sdk"
-  packages = ["pkg/restmapper"]
-  pruneopts = "UT"
-  revision = "e35ec7b722ba095e6438f63fafb9e7326870b486"
-  version = "v0.15.1"
 
 [[projects]]
   digest = "1:9e1d37b58d17113ec3cb5608ac0382313c5b59470b94ed97d0976e69c7022314"
@@ -195,6 +188,17 @@
   packages = ["rate"]
   pruneopts = "UT"
   revision = "555d28b269f0569763d25dbe1a237ae74c6bcc82"
+
+[[projects]]
+  branch = "master"
+  digest = "1:918a46e4a2fb83df33f668f5a6bd51b2996775d073fce1800d3ec01b0a5ddd2b"
+  name = "golang.org/x/xerrors"
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = "UT"
+  revision = "9bdfabe68543c54f90421aeb9a60ef8061b5b544"
 
 [[projects]]
   digest = "1:e0a1881f9e0564bebdeac98c75e59f07acdde6ed3a5396e0e613eaad31194866"
@@ -344,8 +348,8 @@
     "util/keyutil",
   ]
   pruneopts = "UT"
-  revision = "78d2af792babf2dd937ba2e2a8d99c753a5eda89"
-  version = "v12.0.0"
+  revision = "06eb1244587a17d4994ff9de4ce93756a2f16f0b"
+  version = "kubernetes-1.15.4"
 
 [[projects]]
   digest = "1:fd24a140b16df03386fb0d9da8a5879e3b0178f35fff6545d3101f70ff9a4f1a"
@@ -371,6 +375,14 @@
   revision = "c2654d5206da"
 
 [[projects]]
+  digest = "1:37e05f80b83ed690540056bcf6cacc4f9027743d8d21dcf9f1aebbd6ac48bb2c"
+  name = "sigs.k8s.io/controller-runtime"
+  packages = ["pkg/client/apiutil"]
+  pruneopts = "UT"
+  revision = "d21241119ea4de139f1892ba2f5bc72c96d07f3f"
+  version = "v0.3.0"
+
+[[projects]]
   digest = "1:7719608fe0b52a4ece56c2dde37bedd95b938677d1ab0f84b8a7852e4c59f849"
   name = "sigs.k8s.io/yaml"
   packages = ["."]
@@ -383,13 +395,13 @@
   analyzer-version = 1
   input-imports = [
     "github.com/manifestival/manifestival",
-    "github.com/operator-framework/operator-sdk/pkg/restmapper",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/client-go/dynamic",
     "k8s.io/client-go/rest",
+    "sigs.k8s.io/controller-runtime/pkg/client/apiutil",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,8 +30,8 @@
   branch = "master"
 
 [[constraint]]
-  name = "github.com/operator-framework/operator-sdk"
-  version = "0.15.1"
+  name = "sigs.k8s.io/controller-runtime"
+  version = "0.3.0"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
@@ -39,7 +39,7 @@
 
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "12.0.0"
+  version = "kubernetes-1.15.4"
 
 [prune]
   go-tests = true

--- a/client.go
+++ b/client.go
@@ -2,13 +2,13 @@ package client
 
 import (
 	mf "github.com/manifestival/manifestival"
-	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 func NewManifest(pathname string, config *rest.Config, opts ...mf.Option) (mf.Manifest, error) {
@@ -24,7 +24,7 @@ func NewClient(config *rest.Config) (mf.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	mapper, err := restmapper.NewDynamicRESTMapper(config)
+	mapper, err := apiutil.NewDynamicRESTMapper(config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
0.3.0 is the controller-runtime version carrying dependencies to k8s 1.15.4, so that fits neatly. `operator-sdk` upstreamed the dynamic restmapper into controller-runtime so why not just switch over?

Also: Move the client-go dep to be consistent with all k8s deps.